### PR TITLE
Add native macOS Apple Silicon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
-game/
+game/*
+!game/README.md
 *.swp
 *.swo
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ game/
 *~
 .DS_Store
 Thumbs.db
+build-macos/
+.venv-macos/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 📖 [Español](readme_spanish.md) · **English**
 
-**Runs the real native library of *Plants vs. Zombies 2* for Android (`libPVZ2.so`, ARM32) on PC.** The only thing that is emulated is the **CPU**: PvZ2 exists only compiled for ARM (there is no x86/x64 build), so a JIT translates its ARM instructions to x86_64. Everything else — Android, JNI, libc, OpenGL ES, the filesystem — **is not emulated, it is reimplemented natively**, the same way **Wine** does with Windows.
+**Runs the real native library of *Plants vs. Zombies 2* for Android (`libPVZ2.so`, ARM32) on PC.** The only thing that is emulated is the **CPU**: PvZ2 exists only compiled for ARM (there is no x86/x64 build), so a JIT translates its ARM instructions to the native host architecture (x86_64 or arm64). Everything else — Android, JNI, libc, OpenGL ES, the filesystem — **is not emulated, it is reimplemented natively**, the same way **Wine** does with Windows.
 
 > [!WARNING]
 > Experimental project under active development. It boots as far as the main-menu load; rendering, audio and input are work in progress. **The game is not included**: you must supply your own `libPVZ2.so` and your own `.obb`.
@@ -13,7 +13,7 @@
 
 It is not a *port* of the game's source code. It is a **hybrid of two techniques**, and the distinction matters:
 
-- **Only the CPU is emulated.** The game binary is ARM machine code and PvZ2 was never compiled for x86/x64, so there is no way to run it directly on a PC processor. A JIT (dynarmic) reads those ARM instructions and translates them to x86_64 on the fly. This is the only "emulated" part.
+- **Only the CPU is emulated.** The game binary is ARM machine code and PvZ2 was never compiled for x86/x64, so there is no way to run it directly on a PC processor. A JIT (dynarmic) reads those ARM instructions and translates them to the native host architecture (x86_64 or arm64) on the fly. This is the only "emulated" part.
 - **Android is NOT emulated: it is reimplemented.** When the game calls an Android function (open a file, draw with OpenGL ES, allocate memory, invoke Java…), that call is serviced by **native PC code** that does the real work using the equivalent desktop API. There is no virtual Android running underneath; there is a **reimplementation** of the functions the game needs.
 
 This is exactly **Wine's** approach — *"Wine Is Not an Emulator"* — taken one step further: Wine reimplements Windows calls without emulating anything because `.exe` files are already x86; here, because the game is ARM, the CPU has to be emulated as well. The rest of the philosophy is identical: **translate calls, don't simulate a whole machine.**
@@ -25,7 +25,7 @@ This is exactly **Wine's** approach — *"Wine Is Not an Emulator"* — taken on
                         │  ARM instructions
                         ▼
 ┌──────────────────────────────────────────────┐
-│   dynarmic  —  JIT ARM32 → x86_64             │   ← ONLY emulated component
+│   dynarmic  —  JIT ARM32 → x86_64 / arm64     │   ← ONLY emulated component
 └───────────────────────┬──────────────────────┘      (the CPU only)
                         │  "Android" calls
                         ▼
@@ -39,7 +39,7 @@ This is exactly **Wine's** approach — *"Wine Is Not an Emulator"* — taken on
                         │
                         ▼
 ┌──────────────────────────────────────────────┐
-│   Windows x64  ·  SDL2  ·  OpenGL 2.0 (glad)  │
+│ Windows/Linux x64 · macOS arm64 · SDL2 · OpenGL │
 └──────────────────────────────────────────────┘
 ```
 
@@ -85,10 +85,11 @@ Adding a new version = one entry in `kVersions` in [symbols.cpp](pvz2native/src/
 
 ## ⚙️ Requirements
 
-- **(64-bit) Windows or Linux** (the executable is static x86_64; there is no 32-bit build — dynarmic only ships backends for x86_64/arm64/riscv64).
+- **64-bit Windows or Linux**, or **macOS on Apple Silicon (arm64)**. There is no 32-bit host build — dynarmic ships host backends for x86_64, arm64 and riscv64.
 - **CMake** (3.1+).
 - **Windows:** MinGW-w64 (GCC with C++20 support).
 - **Linux:** GCC or Clang with C++20 support.
+- **macOS Apple Silicon:** Apple Clang / Xcode Command Line Tools, Ninja and Python 3.
 - A **GPU with OpenGL 2.0** or higher.
 - Your own copy of **`libPVZ2.so`** and the matching **`.obb`**, extracted from the Android game.
 
@@ -175,6 +176,52 @@ Incremental rebuild (after the first `cmake`):
 cd build
 make pvz2native
 ```
+
+### macOS (Apple Silicon)
+
+The macOS build runs natively on Apple Silicon (`arm64`). The helper script
+creates its own Python virtual environment for GLAD, configures CMake for
+`arm64`, and builds the A32 guest frontend with Dynarmic's AArch64 host backend.
+
+Requirements:
+
+- Xcode Command Line Tools / Apple Clang
+- CMake
+- Ninja
+- Python 3
+
+Build a Release version:
+
+```bash
+./compile-macos.sh
+```
+
+Useful options:
+
+| Option | Description |
+| --- | --- |
+| `-c, --clean` | Delete `build-macos/` before configuring |
+| `-d, --debug` | Configure a Debug build |
+| `-r, --release` | Configure a Release build (default) |
+| `-j, --jobs N` | Build using `N` parallel jobs |
+| `-h, --help` | Show the available options |
+
+Examples:
+
+```bash
+./compile-macos.sh --clean --release
+./compile-macos.sh --debug
+./compile-macos.sh --jobs 4
+```
+
+The executable ends up at:
+
+```text
+build-macos/pvz2native/pvz2native
+```
+
+The script does **not** include or download any game files. Supply your own
+legal `libPVZ2.so` and matching `.obb` as described below.
 
 ---
 
@@ -269,6 +316,7 @@ PvZ2Native/
 ├── SDL/  glad/  zlib/  stb/  third_party/
 ├── compile.bat           ← MinGW build
 ├── compile.sh            ← Linux build
+├── compile-macos.sh      ← macOS Apple Silicon build
 ├── CMakeLists.txt
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Adding a new version = one entry in `kVersions` in [symbols.cpp](pvz2native/src/
 - **Linux:** GCC or Clang with C++20 support.
 - **macOS Apple Silicon:** Apple Clang / Xcode Command Line Tools, Ninja and Python 3.
 - A **GPU with OpenGL 2.0** or higher.
-- Your own copy of **`libPVZ2.so`** and the matching **`.obb`**, extracted from the Android game.
+- Your own legal game files. On macOS the easiest setup is **one APK + its matching OBB**; `compile-macos.sh` extracts the required ARM32 `libPVZ2.so` automatically.
 
 ---
 
@@ -179,32 +179,138 @@ make pvz2native
 
 ### macOS (Apple Silicon)
 
-The macOS build runs natively on Apple Silicon (`arm64`). The helper script
-creates its own Python virtual environment for GLAD, configures CMake for
-`arm64`, and builds the A32 guest frontend with Dynarmic's AArch64 host backend.
+The macOS build runs **natively on Apple Silicon (`arm64`)**. PvZ2's Android
+`libPVZ2.so` is still ARM32; Dynarmic translates that A32 guest code to the
+AArch64 host at runtime.
 
-Requirements:
+> [!IMPORTANT]
+> PvZ2Native does **not** include, host or download Plants vs. Zombies 2.
+> You must provide files from your own legally obtained copy of the game.
 
-- Xcode Command Line Tools / Apple Clang
-- CMake
-- Ninja
-- Python 3
+#### Beginner setup — only two game files
 
-Build a Release version:
+You do **not** need to open the APK or extract `libPVZ2.so` yourself.
+
+1. Clone the repository with its submodules:
+
+```bash
+git clone --recursive https://github.com/OptiJuegos/PvZ2Native.git
+cd PvZ2Native
+```
+
+2. Install the macOS build tools if needed:
+
+```bash
+xcode-select --install
+```
+
+With Homebrew installed:
+
+```bash
+brew install cmake ninja python3
+```
+
+3. Open the `game/` folder and put exactly **one APK** plus its **matching OBB**
+   directly inside it:
+
+```text
+PvZ2Native/
+├── game/
+│   ├── your-own-pvz2-copy.apk
+│   └── main.<versionCode>.<package>.obb
+├── compile-macos.sh
+└── ...
+```
+
+For example, one of the currently supported OBB names is:
+
+```text
+main.147.com.ea.game.pvz2_row.obb
+```
+
+Do not rename the OBB. Its filename contains information used by the game.
+
+4. Build:
 
 ```bash
 ./compile-macos.sh
 ```
 
-Useful options:
+The script will:
+
+```text
+check macOS / Apple Silicon tools
+        ↓
+find your APK and OBB in game/
+        ↓
+extract lib/armeabi-v7a/libPVZ2.so from the APK
+        ↓
+verify that libPVZ2.so is an ARM32 ELF
+        ↓
+configure CMake for native macOS arm64
+        ↓
+build PvZ2Native
+        ↓
+copy the prepared game files to build-macos/pvz2native/lib/
+```
+
+Nothing is downloaded from EA/PopCap and nothing from `game/` is committed by
+Git.
+
+5. When the build finishes, run:
+
+```bash
+./build-macos/pvz2native/pvz2native
+```
+
+On macOS a small native launcher appears before the game window. It only edits
+the existing `[video]` settings in `config.ini`, so the normal configuration
+system remains the single source of truth.
+
+The launcher provides:
+
+- starting resolution (`Auto`, `1280×720`, `1920×1080`, `Native`)
+- `60 FPS`, `120 FPS` or `Unlimited`
+- windowed or fullscreen start
+- `Play` / `Cancel`
+
+The executable is produced at:
+
+```text
+build-macos/pvz2native/pvz2native
+```
+
+and should report as a native Apple Silicon executable:
+
+```text
+Mach-O 64-bit executable arm64
+```
+
+#### Advanced / original asset workflow
+
+If you already extracted the Android library yourself, you can use the same
+style as the original project:
+
+```text
+game/
+├── libPVZ2.so
+└── matching-file.obb
+```
+
+When both an APK and `game/libPVZ2.so` are present, the already extracted
+`libPVZ2.so` takes priority.
+
+#### macOS build options
 
 | Option | Description |
 | --- | --- |
 | `-c, --clean` | Delete `build-macos/` before configuring |
-| `-d, --debug` | Configure a Debug build |
-| `-r, --release` | Configure a Release build (default) |
-| `-j, --jobs N` | Build using `N` parallel jobs |
-| `-h, --help` | Show the available options |
+| `-d, --debug` | Build Debug |
+| `-r, --release` | Build Release (default) |
+| `-j, --jobs N` | Use `N` parallel build jobs |
+| `-n, --no-assets` | Build only; do not copy/extract game files |
+| `-v, --verbose` | Print the complete CMake/build output |
+| `-h, --help` | Show help |
 
 Examples:
 
@@ -212,20 +318,31 @@ Examples:
 ./compile-macos.sh --clean --release
 ./compile-macos.sh --debug
 ./compile-macos.sh --jobs 4
+./compile-macos.sh --no-assets
 ```
 
-The executable ends up at:
+The full non-verbose build log is saved to:
 
 ```text
-build-macos/pvz2native/pvz2native
+build-macos/compile-macos.log
 ```
-
-The script does **not** include or download any game files. Supply your own
-legal `libPVZ2.so` and matching `.obb` as described below.
 
 ---
 
 ## ▶️ Running
+
+### macOS
+
+After `./compile-macos.sh` has prepared the build and your own game files:
+
+```bash
+./build-macos/pvz2native/pvz2native
+```
+
+The native macOS video launcher appears first; choosing **Play** continues into
+the same PvZ2Native core used by the command-line executable.
+
+### General / manual layout
 
 1. Place the game files next to the executable, by default in a `lib/` folder:
 

--- a/compile-macos.sh
+++ b/compile-macos.sh
@@ -1,148 +1,414 @@
-#!/usr/bin/env bash
+#!/bin/bash
+#
+# compile-macos.sh - Native Apple Silicon build script for PvZ2Native.
+#
+# Mirrors the original compile.sh philosophy:
+#   1. build the open-source project from source with CMake
+#   2. optionally prepare user-supplied game assets from game/
+#
+# The game is NOT included and nothing is downloaded from EA/PopCap.
+# Easy path: ONE legal APK + ONE matching OBB in game/.
+# Advanced path: libPVZ2.so + ONE matching OBB in game/.
+#
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BUILD_DIR="$ROOT_DIR/build-macos"
-VENV_DIR="$ROOT_DIR/.venv-macos"
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${PROJECT_ROOT}/build-macos"
+GAME_DIR="${PROJECT_ROOT}/game"
+EXE_DIR="${BUILD_DIR}/pvz2native"
+LIB_DIR="${EXE_DIR}/lib"
+LOG_FILE="${BUILD_DIR}/compile-macos.log"
+VENV_DIR="${PROJECT_ROOT}/.venv-macos"
+BOOST_ROOT="${PROJECT_ROOT}/third_party/boost_1_84_0"
 
 BUILD_TYPE="Release"
-CLEAN=0
+CLEAN="no"
+NO_ASSETS="no"
 JOBS=""
+VERBOSE="no"
+
+# PvZ2Native runs the Android ARM32 library through Dynarmic A32.
+APK_LIB_PATH="lib/armeabi-v7a/libPVZ2.so"
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    RED=$'\e[31m'
+    GREEN=$'\e[32m'
+    YELLOW=$'\e[33m'
+    BLUE=$'\e[34m'
+    BOLD=$'\e[1m'
+    RESET=$'\e[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    BOLD=''
+    RESET=''
+fi
+
+info()    { echo "${BLUE}[INFO]${RESET} $*"; }
+success() { echo "${GREEN}[OK]${RESET} $*"; }
+warn()    { echo "${YELLOW}[WARN]${RESET} $*" >&2; }
+error()   { echo "${RED}[ERROR]${RESET} $*" >&2; }
+fail()    { error "$*"; exit 1; }
 
 usage() {
-    cat <<USAGE
-Usage: ./compile-macos.sh [options]
+    cat <<EOF
+Usage: $0 [OPTIONS]
 
-Build PvZ2Native natively for Apple Silicon macOS.
+Build PvZ2Native natively for macOS Apple Silicon and optionally prepare
+user-supplied game assets from game/.
 
 Options:
-  -c, --clean       Delete build-macos before configuring
-  -d, --debug       Build Debug
-  -r, --release     Build Release (default)
-  -j, --jobs N      Parallel build jobs
-  -h, --help        Show this help
-USAGE
+  -c, --clean          Delete build-macos/ before configuring
+  -d, --debug          Build in Debug mode
+  -r, --release        Build in Release mode (default)
+  -j, --jobs N         Use N parallel jobs
+  -n, --no-assets      Build only; do not copy/extract game assets
+  -v, --verbose        Print full CMake/build output
+  -h, --help           Show this help
+
+Easy game setup:
+  Put exactly ONE APK and ONE matching OBB directly inside:
+
+      ${GAME_DIR}/
+
+  Example:
+      game/
+      ├── PlantsVsZombies2.apk
+      └── main.147.com.ea.game.pvz2_row.obb
+
+  You do NOT need to extract the APK yourself. This script extracts the ARM32
+  libPVZ2.so automatically.
+
+Advanced setup:
+      game/
+      ├── libPVZ2.so
+      └── <matching game>.obb
+
+The game is not included and this script never downloads game files.
+EOF
 }
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        -c|--clean)
-            CLEAN=1
-            shift
-            ;;
-        -d|--debug)
-            BUILD_TYPE="Debug"
-            shift
-            ;;
-        -r|--release)
-            BUILD_TYPE="Release"
-            shift
-            ;;
-        -j|--jobs)
-            if [[ $# -lt 2 ]]; then
-                echo "error: --jobs requires a number" >&2
-                exit 1
-            fi
-            JOBS="$2"
-            shift 2
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        *)
-            echo "error: unknown option: $1" >&2
-            usage >&2
-            exit 1
-            ;;
-    esac
-done
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -c|--clean) CLEAN="yes"; shift ;;
+            -d|--debug) BUILD_TYPE="Debug"; shift ;;
+            -r|--release) BUILD_TYPE="Release"; shift ;;
+            -j|--jobs)
+                if [[ -z "${2:-}" || "$2" =~ ^- ]] || ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" == "0" ]]; then
+                    fail "Option $1 requires a positive integer"
+                fi
+                JOBS="$2"
+                shift 2
+                ;;
+            -n|--no-assets) NO_ASSETS="yes"; shift ;;
+            -v|--verbose) VERBOSE="yes"; shift ;;
+            -h|--help) usage; exit 0 ;;
+            -*) fail "Unknown option: $1 (use --help)" ;;
+            *) fail "Unexpected argument: $1" ;;
+        esac
+    done
+}
 
-if [[ "$(uname -s)" != "Darwin" ]]; then
-    echo "error: compile-macos.sh must be run on macOS" >&2
-    exit 1
-fi
+check_host_and_deps() {
+    [[ "$(uname -s)" == "Darwin" ]] || fail "This script is for macOS only."
+    [[ "$(uname -m)" == "arm64" ]] || fail "Apple Silicon (arm64) is required."
 
-if [[ "$(uname -m)" != "arm64" ]]; then
-    echo "error: this macOS build is currently validated only on Apple Silicon (arm64)" >&2
-    exit 1
-fi
+    local missing=()
+    for cmd in cmake ninja python3 unzip file; do
+        command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+    done
 
-for tool in cmake ninja python3; do
-    if ! command -v "$tool" >/dev/null 2>&1; then
-        echo "error: required tool '$tool' was not found in PATH" >&2
+    if ! xcrun --find clang >/dev/null 2>&1; then
+        missing+=("Xcode Command Line Tools / Apple Clang")
+    fi
+
+    [[ -d "${BOOST_ROOT}" ]] || fail "Bundled Boost not found: ${BOOST_ROOT}"
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo
+        error "Missing required tools: ${missing[*]}"
+        echo "Install Apple's command line tools with:"
+        echo "  xcode-select --install"
+        echo
+        echo "With Homebrew installed, install the remaining tools with:"
+        echo "  brew install cmake ninja python3"
         exit 1
     fi
-done
+}
 
-BOOST_DIR="$ROOT_DIR/third_party/boost_1_84_0"
+prepare_python() {
+    if [[ ! -x "${VENV_DIR}/bin/python" ]]; then
+        info "Creating Python environment for GLAD..."
+        python3 -m venv "${VENV_DIR}"
+    fi
 
-if [[ ! -d "$BOOST_DIR" ]]; then
-    echo "error: bundled Boost directory not found:" >&2
-    echo "  $BOOST_DIR" >&2
-    exit 1
-fi
+    if ! "${VENV_DIR}/bin/python" -c 'import jinja2' >/dev/null 2>&1; then
+        info "Installing Jinja2 in .venv-macos..."
+        "${VENV_DIR}/bin/python" -m pip install "Jinja2>=3.1,<4"
+    fi
+}
 
-if [[ ! -d "$VENV_DIR" ]]; then
-    echo "==> Creating Python environment for GLAD"
-    python3 -m venv "$VENV_DIR"
-fi
+scan_game_dir() {
+    shopt -s nullglob nocaseglob
+    GAME_APKS=("${GAME_DIR}"/*.apk)
+    GAME_OBBS=("${GAME_DIR}"/*.obb)
+    GAME_SO=""
+    [[ -f "${GAME_DIR}/libPVZ2.so" ]] && GAME_SO="${GAME_DIR}/libPVZ2.so"
+    shopt -u nocaseglob
+}
 
-PYTHON="$VENV_DIR/bin/python"
+show_asset_plan() {
+    echo
+    echo "${BOLD}Game files${RESET}"
+    echo "  Folder: ${GAME_DIR}"
 
-if ! "$PYTHON" -c 'import jinja2' >/dev/null 2>&1; then
-    echo "==> Installing Jinja2 for GLAD"
-    "$PYTHON" -m pip install "Jinja2>=3.1,<4"
-fi
+    if [[ ! -d "${GAME_DIR}" ]]; then
+        warn "game/ does not exist."
+        echo "  Create it and put your own APK + matching OBB inside."
+        return
+    fi
 
-if [[ "$CLEAN" -eq 1 ]]; then
-    echo "==> Removing previous macOS build"
-    rm -rf "$BUILD_DIR"
-fi
+    scan_game_dir
 
-echo "==> Configuring PvZ2Native"
-echo "    Host:       macOS arm64"
-echo "    Build type: $BUILD_TYPE"
-echo "    Build dir:  $BUILD_DIR"
+    if [[ -n "${GAME_SO}" ]]; then
+        success "Found libPVZ2.so (advanced setup)"
+        if [[ ${#GAME_APKS[@]} -gt 0 ]]; then
+            info "An APK is also present; libPVZ2.so takes priority."
+        fi
+    elif [[ ${#GAME_APKS[@]} -eq 1 ]]; then
+        success "Found APK: $(basename "${GAME_APKS[0]}")"
+        info "libPVZ2.so will be extracted automatically."
+    elif [[ ${#GAME_APKS[@]} -eq 0 ]]; then
+        warn "No APK or libPVZ2.so found."
+        echo "  Put ONE legal PvZ2 APK directly inside game/."
+    else
+        warn "More than one APK found."
+        echo "  Leave only ONE APK in game/."
+    fi
 
-cmake \
-    -S "$ROOT_DIR" \
-    -B "$BUILD_DIR" \
-    -G Ninja \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-    -DCMAKE_OSX_ARCHITECTURES=arm64 \
-    -DBoost_ROOT="$BOOST_DIR" \
-    -DPython_EXECUTABLE="$PYTHON" \
-    -DCMAKE_CXX_FLAGS="-DFMT_CONSTEVAL=" \
-    -DDYNARMIC_USE_PRECOMPILED_HEADERS=OFF
+    if [[ ${#GAME_OBBS[@]} -eq 1 ]]; then
+        success "Found OBB: $(basename "${GAME_OBBS[0]}")"
+    elif [[ ${#GAME_OBBS[@]} -eq 0 ]]; then
+        warn "No OBB found."
+        echo "  Put the matching .obb directly inside game/."
+    else
+        warn "More than one OBB found."
+        echo "  Leave only ONE OBB in game/."
+    fi
+}
 
-echo "==> Building PvZ2Native"
+configure() {
+    info "Configuring PvZ2Native"
+    echo "    Host:       macOS arm64"
+    echo "    Build type: ${BUILD_TYPE}"
+    echo "    Build dir:  ${BUILD_DIR}"
 
-if [[ -n "$JOBS" ]]; then
-    cmake --build "$BUILD_DIR" \
-        --target pvz2native \
-        --parallel "$JOBS"
-else
-    cmake --build "$BUILD_DIR" \
-        --target pvz2native
-fi
+    local args=(
+        -G Ninja
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+        -DCMAKE_OSX_ARCHITECTURES=arm64
+        -DBoost_ROOT="${BOOST_ROOT}"
+        -DPython_EXECUTABLE="${VENV_DIR}/bin/python"
+        -DCMAKE_CXX_FLAGS=-DFMT_CONSTEVAL=
+        -DDYNARMIC_USE_PRECOMPILED_HEADERS=OFF
+        "${PROJECT_ROOT}"
+    )
 
-BINARY="$BUILD_DIR/pvz2native/pvz2native"
+    if [[ "${VERBOSE}" == "yes" ]]; then
+        cmake "${args[@]}"
+    else
+        cmake "${args[@]}" >>"${LOG_FILE}" 2>&1 || {
+            error "CMake configuration failed."
+            echo "See: ${LOG_FILE}"
+            exit 1
+        }
+    fi
+}
 
-if [[ ! -x "$BINARY" ]]; then
-    echo "error: build completed but executable was not found:" >&2
-    echo "  $BINARY" >&2
-    exit 1
-fi
+build_project() {
+    info "Building PvZ2Native"
 
-echo
-echo "==> Build complete"
-file "$BINARY"
+    local args=(--build "${BUILD_DIR}" --target pvz2native)
+    if [[ -n "${JOBS}" ]]; then
+        args+=(--parallel "${JOBS}")
+    fi
 
-echo
-echo "Executable:"
-echo "  $BINARY"
-echo
-echo "Game files are NOT included."
-echo "Provide your own legal libPVZ2.so and matching .obb as documented in README.md."
+    if [[ "${VERBOSE}" == "yes" ]]; then
+        cmake "${args[@]}"
+    else
+        cmake "${args[@]}" >>"${LOG_FILE}" 2>&1 || {
+            error "Build failed."
+            echo "See: ${LOG_FILE}"
+            exit 1
+        }
+    fi
+
+    [[ -x "${EXE_DIR}/pvz2native" ]] || fail "Executable was not produced."
+}
+
+validate_arm32_so() {
+    local so="$1"
+    local desc
+    desc="$(file "$so")"
+
+    if [[ "$desc" != *"ELF 32-bit"* || "$desc" != *"ARM"* ]]; then
+        error "libPVZ2.so is not the ARM32 library PvZ2Native expects."
+        echo "Detected:"
+        echo "  $desc"
+        return 1
+    fi
+    return 0
+}
+
+prepare_assets() {
+    if [[ "${NO_ASSETS}" == "yes" ]]; then
+        info "Skipping game assets (--no-assets)"
+        return 0
+    fi
+
+    if [[ ! -d "${GAME_DIR}" ]]; then
+        warn "No game/ folder. Build succeeded, but game files were not prepared."
+        return 0
+    fi
+
+    scan_game_dir
+
+    if [[ -z "${GAME_SO}" && ${#GAME_APKS[@]} -gt 1 ]]; then
+        fail "More than one APK is inside game/. Leave only one and run again."
+    fi
+    if [[ ${#GAME_OBBS[@]} -gt 1 ]]; then
+        fail "More than one OBB is inside game/. Leave only one and run again."
+    fi
+
+    mkdir -p "${LIB_DIR}"
+
+    local source_so=""
+    local temp_so=""
+
+    if [[ -n "${GAME_SO}" ]]; then
+        source_so="${GAME_SO}"
+        info "Using game/libPVZ2.so"
+    elif [[ ${#GAME_APKS[@]} -eq 1 ]]; then
+        local apk="${GAME_APKS[0]}"
+        temp_so="${BUILD_DIR}/libPVZ2.extracted.tmp"
+        rm -f "${temp_so}"
+
+        info "Extracting ${APK_LIB_PATH}"
+        echo "    from: $(basename "${apk}")"
+
+        if ! unzip -p "${apk}" "${APK_LIB_PATH}" >"${temp_so}" 2>/dev/null; then
+            rm -f "${temp_so}"
+            fail "This APK does not contain ${APK_LIB_PATH}. PvZ2Native needs the ARM32 library."
+        fi
+
+        [[ -s "${temp_so}" ]] || {
+            rm -f "${temp_so}"
+            fail "The APK extraction produced an empty libPVZ2.so."
+        }
+
+        source_so="${temp_so}"
+        success "libPVZ2.so extracted from APK"
+    else
+        warn "No APK or libPVZ2.so in game/. Build succeeded; no library was copied."
+    fi
+
+    if [[ -n "${source_so}" ]]; then
+        validate_arm32_so "${source_so}" || {
+            rm -f "${temp_so}"
+            fail "Use an APK/library containing the ARM32 armeabi-v7a build."
+        }
+        cp "${source_so}" "${LIB_DIR}/libPVZ2.so"
+        rm -f "${temp_so}"
+        success "Prepared lib/libPVZ2.so"
+    fi
+
+    if [[ ${#GAME_OBBS[@]} -eq 1 ]]; then
+        rm -f "${LIB_DIR}"/*.obb
+        cp "${GAME_OBBS[0]}" "${LIB_DIR}/"
+        success "Prepared lib/$(basename "${GAME_OBBS[0]}")"
+    else
+        warn "No OBB in game/. Build succeeded; no OBB was copied."
+    fi
+}
+
+summary() {
+    echo
+    echo "${BOLD}============================================================${RESET}"
+    echo "${BOLD} PvZ2Native macOS build complete${RESET}"
+    echo "${BOLD}============================================================${RESET}"
+    echo
+    file "${EXE_DIR}/pvz2native"
+    echo
+    echo "Executable:"
+    echo "  ${EXE_DIR}/pvz2native"
+    echo
+
+    local have_so="no"
+    local have_obb="no"
+    [[ -f "${LIB_DIR}/libPVZ2.so" ]] && have_so="yes"
+
+    shopt -s nullglob
+    local out_obbs=("${LIB_DIR}"/*.obb)
+    shopt -u nullglob
+    [[ ${#out_obbs[@]} -gt 0 ]] && have_obb="yes"
+
+    if [[ "${NO_ASSETS}" == "yes" ]]; then
+        info "Game asset handling was disabled."
+    elif [[ "${have_so}" == "yes" && "${have_obb}" == "yes" ]]; then
+        success "Game files are ready."
+        echo
+        echo "Start PvZ2Native with:"
+        echo "  ./build-macos/pvz2native/pvz2native"
+        echo
+        echo "The macOS launcher lets you choose resolution, FPS and fullscreen."
+    else
+        warn "The program compiled, but game files are incomplete."
+        echo
+        echo "For the easy setup, put these TWO files directly in:"
+        echo "  ${GAME_DIR}/"
+        echo
+        echo "  1. ONE legal PvZ2 .apk"
+        echo "  2. ONE matching .obb"
+        echo
+        echo "Then run:"
+        echo "  ./compile-macos.sh"
+        echo
+        echo "You do NOT need to extract libPVZ2.so yourself."
+    fi
+
+    echo
+    echo "Build log:"
+    echo "  ${LOG_FILE}"
+    echo
+    echo "Game files are never included in the repository or downloaded by this script."
+}
+
+main() {
+    parse_args "$@"
+    check_host_and_deps
+    show_asset_plan
+    prepare_python
+
+    if [[ "${CLEAN}" == "yes" ]]; then
+        warn "Cleaning build directory: ${BUILD_DIR}"
+        rm -rf "${BUILD_DIR}"
+    fi
+
+    mkdir -p "${BUILD_DIR}"
+    : >"${LOG_FILE}"
+
+    cd "${BUILD_DIR}"
+    configure
+    cd "${PROJECT_ROOT}"
+
+    build_project
+    prepare_assets
+    summary
+}
+
+trap 'error "Interrupted"; exit 130' INT TERM
+main "$@"

--- a/compile-macos.sh
+++ b/compile-macos.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$ROOT_DIR/build-macos"
+VENV_DIR="$ROOT_DIR/.venv-macos"
+
+BUILD_TYPE="Release"
+CLEAN=0
+JOBS=""
+
+usage() {
+    cat <<USAGE
+Usage: ./compile-macos.sh [options]
+
+Build PvZ2Native natively for Apple Silicon macOS.
+
+Options:
+  -c, --clean       Delete build-macos before configuring
+  -d, --debug       Build Debug
+  -r, --release     Build Release (default)
+  -j, --jobs N      Parallel build jobs
+  -h, --help        Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c|--clean)
+            CLEAN=1
+            shift
+            ;;
+        -d|--debug)
+            BUILD_TYPE="Debug"
+            shift
+            ;;
+        -r|--release)
+            BUILD_TYPE="Release"
+            shift
+            ;;
+        -j|--jobs)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --jobs requires a number" >&2
+                exit 1
+            fi
+            JOBS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "error: compile-macos.sh must be run on macOS" >&2
+    exit 1
+fi
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+    echo "error: this macOS build is currently validated only on Apple Silicon (arm64)" >&2
+    exit 1
+fi
+
+for tool in cmake ninja python3; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "error: required tool '$tool' was not found in PATH" >&2
+        exit 1
+    fi
+done
+
+BOOST_DIR="$ROOT_DIR/third_party/boost_1_84_0"
+
+if [[ ! -d "$BOOST_DIR" ]]; then
+    echo "error: bundled Boost directory not found:" >&2
+    echo "  $BOOST_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "==> Creating Python environment for GLAD"
+    python3 -m venv "$VENV_DIR"
+fi
+
+PYTHON="$VENV_DIR/bin/python"
+
+if ! "$PYTHON" -c 'import jinja2' >/dev/null 2>&1; then
+    echo "==> Installing Jinja2 for GLAD"
+    "$PYTHON" -m pip install "Jinja2>=3.1,<4"
+fi
+
+if [[ "$CLEAN" -eq 1 ]]; then
+    echo "==> Removing previous macOS build"
+    rm -rf "$BUILD_DIR"
+fi
+
+echo "==> Configuring PvZ2Native"
+echo "    Host:       macOS arm64"
+echo "    Build type: $BUILD_TYPE"
+echo "    Build dir:  $BUILD_DIR"
+
+cmake \
+    -S "$ROOT_DIR" \
+    -B "$BUILD_DIR" \
+    -G Ninja \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    -DCMAKE_OSX_ARCHITECTURES=arm64 \
+    -DBoost_ROOT="$BOOST_DIR" \
+    -DPython_EXECUTABLE="$PYTHON" \
+    -DCMAKE_CXX_FLAGS="-DFMT_CONSTEVAL=" \
+    -DDYNARMIC_USE_PRECOMPILED_HEADERS=OFF
+
+echo "==> Building PvZ2Native"
+
+if [[ -n "$JOBS" ]]; then
+    cmake --build "$BUILD_DIR" \
+        --target pvz2native \
+        --parallel "$JOBS"
+else
+    cmake --build "$BUILD_DIR" \
+        --target pvz2native
+fi
+
+BINARY="$BUILD_DIR/pvz2native/pvz2native"
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "error: build completed but executable was not found:" >&2
+    echo "  $BINARY" >&2
+    exit 1
+fi
+
+echo
+echo "==> Build complete"
+file "$BINARY"
+
+echo
+echo "Executable:"
+echo "  $BINARY"
+echo
+echo "Game files are NOT included."
+echo "Provide your own legal libPVZ2.so and matching .obb as documented in README.md."

--- a/game/README.md
+++ b/game/README.md
@@ -1,0 +1,34 @@
+# Game files go here
+
+PvZ2Native does **not** include or download Plants vs. Zombies 2.
+
+For the easiest setup, put exactly **two files** in this folder:
+
+```text
+game/
+├── your-own-copy.apk
+└── matching-file.obb
+```
+
+Then return to the `PvZ2Native` folder and run:
+
+```bash
+./compile-macos.sh
+```
+
+On macOS Apple Silicon the script extracts the required ARM32
+`libPVZ2.so` from the APK automatically and copies the matching OBB into the
+build folder.
+
+You do **not** need to open the APK or extract `libPVZ2.so` yourself.
+
+Advanced users may instead provide:
+
+```text
+game/
+├── libPVZ2.so
+└── matching-file.obb
+```
+
+Only use files from your own legally obtained copy of the game. Game files are
+ignored by Git and must never be committed to this repository.

--- a/pvz2native/CMakeLists.txt
+++ b/pvz2native/CMakeLists.txt
@@ -4,6 +4,20 @@ project(pvz2native-core)
 
 file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS src/*.c src/*.cpp)
 
+# Keep Objective-C out of CMake's language initialisation. The project already
+# uses Clang as its C compiler on macOS; this one source is compiled through the
+# normal C rule with Clang explicitly switched to Objective-C mode. This avoids
+# requiring a separate CMAKE_OBJC_COMPILE_OBJECT rule in nested/subproject builds.
+if (APPLE)
+    set(MACOS_LAUNCHER_SOURCE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/platform/macos/launcher_objc.c")
+    set_source_files_properties(
+        "${MACOS_LAUNCHER_SOURCE}"
+        PROPERTIES
+            COMPILE_OPTIONS "-x;objective-c;-fobjc-arc"
+    )
+endif()
+
 # stb_vorbis is gone with src/audio/sound_repository.c, its only consumer. That
 # file, src/audio/sles.c and src/audio/audio_engine.c were an older OpenSL
 # implementation with no callers left: the live audio path is the guest-vtable
@@ -11,6 +25,11 @@ file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS src/*.c src/*.cpp)
 add_executable(pvz2native ${SOURCE_FILES})
 target_include_directories(pvz2native PUBLIC include/)
 target_link_libraries(pvz2native ${CMAKE_DL_LIBS} zlibstatic SDL2::SDL2 SDL2main glad dynarmic)
+
+if (APPLE)
+    find_library(COCOA_FRAMEWORK Cocoa REQUIRED)
+    target_link_libraries(pvz2native ${COCOA_FRAMEWORK})
+endif()
 include_directories(pvz2native PUBLIC include/)
 set_target_properties(pvz2native PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
 

--- a/pvz2native/include/pvz2native/platform/macos_launcher.h
+++ b/pvz2native/include/pvz2native/platform/macos_launcher.h
@@ -1,0 +1,19 @@
+#ifndef PVZ2NATIVE_PLATFORM_MACOS_LAUNCHER_H
+#define PVZ2NATIVE_PLATFORM_MACOS_LAUNCHER_H
+
+#include <pvz2native/config.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Shows the native macOS pre-launch video settings dialog.
+ * Returns 1 when the user chooses Play, 0 when they cancel.
+ * On Play, only the [video] keys in config.ini are updated. */
+int pvz2_macos_show_launcher(const char *ini_path, const pvz2_config_t *cfg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/pvz2native/include/pvz2native/runtime/dynarmic_config.h
+++ b/pvz2native/include/pvz2native/runtime/dynarmic_config.h
@@ -397,6 +397,11 @@ void build_import_handler_cache(pvz2_elf_image_t *img);
  * session. Cleared at shutdown so neither can outlive it. */
 void set_session_image(pvz2_elf_image_t *img, GuestRuntime *rt);
 
+/* Requests a cooperative stop of all long-lived guest workers.
+ * Blocking pthread condition/semaphore waits are awakened so their import
+ * handlers can halt the corresponding JIT before teardown. */
+void request_guest_shutdown(GuestRuntime *rt);
+
 /* Joins any guest thread that outlived the call which spawned it -- their
  * lambdas hold raw pointers to both img and rt, so this must happen before
  * either dies. */

--- a/pvz2native/include/pvz2native/runtime/guest_runtime.h
+++ b/pvz2native/include/pvz2native/runtime/guest_runtime.h
@@ -90,6 +90,13 @@ struct GuestRuntime {
     uint32_t next_thread_id = 2; /* 1 is reserved for the initial/"main" thread */
     uint32_t next_stack_slot = 0;
 
+    /* Session-wide cooperative stop requested by the host during shutdown.
+     * Guest workers may legitimately live for the entire process and block in
+     * pthread_cond_wait/sem_wait, so joining them without first waking them
+     * deadlocks teardown. Blocking shims include this flag in their predicates
+     * and halt their JIT instead of returning into guest code once it is set. */
+    std::atomic<bool> shutdown_requested{false};
+
     std::atomic<uint32_t> next_tls_key{1};
     std::mutex log_lock;
 

--- a/pvz2native/src/config.cpp
+++ b/pvz2native/src/config.cpp
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <string>
 
 namespace {
@@ -164,9 +165,9 @@ const Setting kSettings[] = {
     {"game", "package_name", nullptr, Kind::kString, offsetof(pvz2_config_t, package_name),
      sizeof(g_config.package_name),
      "The Android package name the engine is told it runs as. Must match the\n"
-     "package baked into [paths] obb's filename (main.<versionCode>.<package>.obb)\n"
-     "or the RSB load fails and boot never leaves the loading screen.",
-     "com.ea.game.pvz2_na", nullptr},
+     "package baked into [paths] obb's filename (main.<versionCode>.<package>.obb).\n"
+     "Leave commented to derive it automatically from the OBB filename.",
+     nullptr, "com.ea.game.pvz2_na"},
     {"game", "activity_name", nullptr, Kind::kString, offsetof(pvz2_config_t, activity_name),
      sizeof(g_config.activity_name), "The Activity class name reported back to the engine.",
      "com.popcap.PvZ2.PvZ2GameActivity", nullptr},
@@ -395,6 +396,69 @@ void finish_defaults(const char *base_dir) {
     finish_path(g_config.obb_path, sizeof(g_config.obb_path), base_dir, lib + kDefaultObbName);
     finish_path(g_config.save_dir, sizeof(g_config.save_dir), base_dir,
                 base_with_sep(base_dir) + "save");
+
+    /* If [paths] obb is left unset, prefer the one unambiguous .obb already
+     * present in <exe>/lib. This keeps the original local game-file workflow
+     * while avoiding a manual config edit just because the supported version
+     * uses a different OBB filename. */
+    if (g_config.obb_path[0] == '\0') {
+        const std::filesystem::path lib_dir =
+            std::filesystem::path(base_with_sep(base_dir)) / "lib";
+        std::error_code ec;
+        std::filesystem::path only_obb;
+        unsigned obb_count = 0;
+
+        if (std::filesystem::is_directory(lib_dir, ec)) {
+            for (const auto &entry : std::filesystem::directory_iterator(lib_dir, ec)) {
+                if (ec) break;
+                if (!entry.is_regular_file(ec)) continue;
+                if (lower(entry.path().extension().string()) != ".obb") continue;
+
+                only_obb = entry.path();
+                ++obb_count;
+                if (obb_count > 1) break;
+            }
+        }
+
+        if (obb_count == 1) {
+            set_path(g_config.obb_path, sizeof(g_config.obb_path), only_obb.string());
+        }
+    }
+
+    finish_path(g_config.obb_path, sizeof(g_config.obb_path), base_dir, lib + kDefaultObbName);
+
+    /* main.<versionCode>.<package>.obb carries the Android package name.
+     * Derive it only when config.ini leaves package_name unset; an explicit
+     * config value still wins. */
+    if (g_config.package_name[0] == '\0') {
+        std::string name = g_config.obb_path;
+        const std::size_t slash = name.find_last_of("/\\");
+        if (slash != std::string::npos) name.erase(0, slash + 1);
+
+        constexpr const char prefix[] = "main.";
+        constexpr const char suffix[] = ".obb";
+        if (name.rfind(prefix, 0) == 0 &&
+            name.size() > sizeof(prefix) - 1 + sizeof(suffix) - 1 &&
+            name.compare(name.size() - (sizeof(suffix) - 1),
+                         sizeof(suffix) - 1, suffix) == 0) {
+            const std::size_t version_end = name.find('.', sizeof(prefix) - 1);
+            if (version_end != std::string::npos) {
+                const std::size_t package_begin = version_end + 1;
+                const std::size_t package_len =
+                    name.size() - package_begin - (sizeof(suffix) - 1);
+                if (package_len > 0) {
+                    const std::string package = name.substr(package_begin, package_len);
+                    std::snprintf(g_config.package_name, sizeof(g_config.package_name),
+                                  "%s", package.c_str());
+                }
+            }
+        }
+
+        if (g_config.package_name[0] == '\0') {
+            std::snprintf(g_config.package_name, sizeof(g_config.package_name),
+                          "com.ea.game.pvz2_na");
+        }
+    }
 
     if (g_config.user_locale[0] == '\0')
         std::snprintf(g_config.user_locale, sizeof(g_config.user_locale), "en_US");

--- a/pvz2native/src/dependencies/libc_pthread.cpp
+++ b/pvz2native/src/dependencies/libc_pthread.cpp
@@ -36,8 +36,9 @@ constexpr std::uint32_t kETIMEDOUT = 110;
  * which is the same epoch the host's system_clock uses. */
 std::chrono::system_clock::time_point deadline_from(GuestCall &c, std::uint32_t ts) {
     std::uint32_t sec = c.read32(ts), nsec = c.read32(ts + 4);
-    return std::chrono::system_clock::time_point(std::chrono::seconds(sec) +
-                                                 std::chrono::nanoseconds(nsec));
+    return std::chrono::system_clock::time_point(
+        std::chrono::duration_cast<std::chrono::system_clock::duration>(
+            std::chrono::seconds(sec) + std::chrono::nanoseconds(nsec)));
 }
 
 /* ---------------------------------------------------------------- mutex

--- a/pvz2native/src/dependencies/libc_pthread.cpp
+++ b/pvz2native/src/dependencies/libc_pthread.cpp
@@ -168,11 +168,24 @@ void c_cond_wait(GuestCall &c) {
      * wait still bumps it, so the predicate is already true. */
     std::uint64_t gen = gc->generation;
     gm->unlock(self);
-    if (!gc->cv.wait_for(lk, kStuckWarnAfter, [&] { return gc->generation != gen; })) {
+    if (!gc->cv.wait_for(lk, kStuckWarnAfter, [&] {
+            return gc->generation != gen ||
+                   c.rt->shutdown_requested.load(std::memory_order_acquire);
+        })) {
         c.log("[stuck] tid=%u blocked >3s in pthread_cond_wait(cond=0x%08x, mutex=0x%08x) lr=0x%08x",
               self, c.arg(0), c.arg(1), c.lr());
-        gc->cv.wait(lk, [&] { return gc->generation != gen; });
+        gc->cv.wait(lk, [&] {
+            return gc->generation != gen ||
+                   c.rt->shutdown_requested.load(std::memory_order_acquire);
+        });
     }
+
+    if (c.rt->shutdown_requested.load(std::memory_order_acquire)) {
+        lk.unlock();
+        c.halt("runtime_shutdown");
+        return;
+    }
+
     lk.unlock();
     gm->lock(self);
     c.set_result(0);
@@ -187,7 +200,17 @@ void c_cond_timedwait(GuestCall &c) {
     std::unique_lock<std::mutex> lk(gc->m);
     std::uint64_t gen = gc->generation;
     gm->unlock(self);
-    bool woke = gc->cv.wait_until(lk, deadline, [&] { return gc->generation != gen; });
+    bool woke = gc->cv.wait_until(lk, deadline, [&] {
+        return gc->generation != gen ||
+               c.rt->shutdown_requested.load(std::memory_order_acquire);
+    });
+
+    if (c.rt->shutdown_requested.load(std::memory_order_acquire)) {
+        lk.unlock();
+        c.halt("runtime_shutdown");
+        return;
+    }
+
     lk.unlock();
     gm->lock(self);
     c.set_result(woke ? 0u : kETIMEDOUT);
@@ -275,7 +298,10 @@ void c_sem_wait(GuestCall &c) {
     GuestSem *gs = c.rt->get_or_create_sem(c.arg(0));
     std::unique_lock<std::mutex> lk(gs->m);
     gs->waiters++;
-    if (!gs->cv.wait_for(lk, kStuckWarnAfter, [&] { return gs->count > 0; })) {
+    if (!gs->cv.wait_for(lk, kStuckWarnAfter, [&] {
+            return gs->count > 0 ||
+                   c.rt->shutdown_requested.load(std::memory_order_acquire);
+        })) {
         /* Report with this semaphore's mutex released: the dump walks every
          * other semaphore and would otherwise hold two of them at once. */
         lk.unlock();
@@ -283,8 +309,19 @@ void c_sem_wait(GuestCall &c) {
               c.arg(0), c.lr());
         report_sems(c);
         lk.lock();
-        gs->cv.wait(lk, [&] { return gs->count > 0; });
+        gs->cv.wait(lk, [&] {
+            return gs->count > 0 ||
+                   c.rt->shutdown_requested.load(std::memory_order_acquire);
+        });
     }
+
+    if (c.rt->shutdown_requested.load(std::memory_order_acquire)) {
+        gs->waiters--;
+        lk.unlock();
+        c.halt("runtime_shutdown");
+        return;
+    }
+
     gs->waiters--;
     gs->count--;
     c.set_result(0);
@@ -307,7 +344,15 @@ void c_sem_timedwait(GuestCall &c) {
     GuestSem *gs = c.rt->get_or_create_sem(c.arg(0));
     auto deadline = deadline_from(c, c.arg(1));
     std::unique_lock<std::mutex> lk(gs->m);
-    if (gs->cv.wait_until(lk, deadline, [&] { return gs->count > 0; })) {
+    if (gs->cv.wait_until(lk, deadline, [&] {
+            return gs->count > 0 ||
+                   c.rt->shutdown_requested.load(std::memory_order_acquire);
+        })) {
+        if (c.rt->shutdown_requested.load(std::memory_order_acquire)) {
+            lk.unlock();
+            c.halt("runtime_shutdown");
+            return;
+        }
         gs->count--;
         c.set_result(0);
         return;

--- a/pvz2native/src/main.c
+++ b/pvz2native/src/main.c
@@ -125,7 +125,19 @@ static void update_window_size(void) {
  * X button respond during startup; the OS reclaims everything. */
 static void handle_quit(void) {
     fflush(stdout);
-    exit(0);
+
+    /* During boot we may be trapped for seconds inside one guest call, so
+     * immediate process termination is still required to make the close button
+     * responsive. Once the session is fully booted, however, exit(0) would run
+     * C++ static destructors while Dynarmic guest/Mach-handler threads are still
+     * alive. Request an orderly shutdown instead so the main loop reaches
+     * pvz2_session_end(), which stops audio, joins guest threads and releases
+     * the JIT before SDL and process teardown. */
+    if (!g_booted) {
+        exit(0);
+    }
+
+    g_quit_requested = 1;
 }
 
 /* F11 toggles borderless fullscreen. FULLSCREEN_DESKTOP (not real fullscreen)

--- a/pvz2native/src/main.c
+++ b/pvz2native/src/main.c
@@ -4,6 +4,9 @@
 #include <SDL.h>
 #include <glad/gl.h>
 #include <pvz2native/config.h>
+#ifdef __APPLE__
+#include <pvz2native/platform/macos_launcher.h>
+#endif
 #include <pvz2native/gfx/frame_limiter.h>
 #include <pvz2native/gfx/gl_requirements.h>
 #include <pvz2native/gfx/video_mode.h>
@@ -272,6 +275,18 @@ int main(int argc, char **argv) {
     char ini_path[1024];
     SDL_snprintf(ini_path, sizeof(ini_path), "%sconfig.ini", base_path ? base_path : "");
     pvz2_config_load(ini_path, base_path ? base_path : "");
+
+#ifdef __APPLE__
+    /* macOS keeps the original config.ini workflow. The native launcher only
+     * edits the existing [video] settings, then the same parser reloads them. */
+    if (!pvz2_macos_show_launcher(ini_path, pvz2_config())) {
+        if (base_path) SDL_free(base_path);
+        SDL_Quit();
+        return 0;
+    }
+    pvz2_config_load(ini_path, base_path ? base_path : "");
+#endif
+
     if (base_path) SDL_free(base_path);
     const pvz2_config_t *cfg = pvz2_config();
     printf("so=%s\n", cfg->so_path);

--- a/pvz2native/src/platform/macos/launcher_objc.c
+++ b/pvz2native/src/platform/macos/launcher_objc.c
@@ -1,0 +1,237 @@
+#import <Cocoa/Cocoa.h>
+#include <string.h>
+#include <pvz2native/platform/macos_launcher.h>
+
+static NSString *trimmed(NSString *s) {
+    return [s stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+static NSString *setting_key(NSString *line) {
+    NSString *s = trimmed(line);
+
+    /* Comments are documentation, never active settings. */
+    if ([s hasPrefix:@";"] || [s hasPrefix:@"#"] || s.length == 0) {
+        return nil;
+    }
+
+    NSRange eq = [s rangeOfString:@"="];
+    if (eq.location == NSNotFound) return nil;
+    return trimmed([s substringToIndex:eq.location]);
+}
+
+static void append_missing_video_keys(NSMutableArray<NSString *> *out,
+                                      BOOL seenMode, BOOL seenWidth, BOOL seenHeight,
+                                      BOOL seenFullscreen, BOOL seenFps,
+                                      NSString *mode, NSInteger width, NSInteger height,
+                                      BOOL fullscreen, NSInteger fps) {
+    if (!seenMode)       [out addObject:[NSString stringWithFormat:@"mode = %@", mode]];
+    if (!seenWidth)      [out addObject:[NSString stringWithFormat:@"width = %ld", (long)width]];
+    if (!seenHeight)     [out addObject:[NSString stringWithFormat:@"height = %ld", (long)height]];
+    if (!seenFullscreen) [out addObject:[NSString stringWithFormat:@"fullscreen = %d", fullscreen ? 1 : 0]];
+    if (!seenFps)        [out addObject:[NSString stringWithFormat:@"fps_limit = %ld", (long)fps]];
+}
+
+static BOOL write_video_settings(const char *ini_path,
+                                 NSString *mode, NSInteger width, NSInteger height,
+                                 BOOL fullscreen, NSInteger fps) {
+    if (!ini_path || !*ini_path) return NO;
+
+    NSString *path = [NSString stringWithUTF8String:ini_path];
+    NSError *error = nil;
+    NSString *text = [NSString stringWithContentsOfFile:path
+                                                encoding:NSUTF8StringEncoding
+                                                   error:&error];
+    if (!text) {
+        NSLog(@"PvZ2Native launcher: cannot read config.ini: %@", error);
+        return NO;
+    }
+
+    NSArray<NSString *> *lines = [text componentsSeparatedByCharactersInSet:
+        [NSCharacterSet newlineCharacterSet]];
+    NSMutableArray<NSString *> *out = [NSMutableArray arrayWithCapacity:lines.count + 8];
+
+    BOOL inVideo = NO;
+    BOOL foundVideo = NO;
+    BOOL seenMode = NO, seenWidth = NO, seenHeight = NO, seenFullscreen = NO, seenFps = NO;
+
+    for (NSString *line in lines) {
+        NSString *t = trimmed(line);
+
+        if ([t hasPrefix:@"["] && [t hasSuffix:@"]"]) {
+            if (inVideo) {
+                append_missing_video_keys(out, seenMode, seenWidth, seenHeight,
+                                          seenFullscreen, seenFps,
+                                          mode, width, height, fullscreen, fps);
+            }
+
+            inVideo = [t caseInsensitiveCompare:@"[video]"] == NSOrderedSame;
+            if (inVideo) {
+                foundVideo = YES;
+                seenMode = seenWidth = seenHeight = seenFullscreen = seenFps = NO;
+            }
+
+            [out addObject:line];
+            continue;
+        }
+
+        if (inVideo) {
+            NSString *key = setting_key(line);
+
+            if ([key isEqualToString:@"mode"]) {
+                if (!seenMode) {
+                    [out addObject:[NSString stringWithFormat:@"mode = %@", mode]];
+                    seenMode = YES;
+                }
+                continue;
+            }
+            if ([key isEqualToString:@"width"]) {
+                if (!seenWidth) {
+                    [out addObject:[NSString stringWithFormat:@"width = %ld", (long)width]];
+                    seenWidth = YES;
+                }
+                continue;
+            }
+            if ([key isEqualToString:@"height"]) {
+                if (!seenHeight) {
+                    [out addObject:[NSString stringWithFormat:@"height = %ld", (long)height]];
+                    seenHeight = YES;
+                }
+                continue;
+            }
+            if ([key isEqualToString:@"fullscreen"]) {
+                if (!seenFullscreen) {
+                    [out addObject:[NSString stringWithFormat:@"fullscreen = %d", fullscreen ? 1 : 0]];
+                    seenFullscreen = YES;
+                }
+                continue;
+            }
+            if ([key isEqualToString:@"fps_limit"] || [key isEqualToString:@"fpslimit"]) {
+                if (!seenFps) {
+                    [out addObject:[NSString stringWithFormat:@"fps_limit = %ld", (long)fps]];
+                    seenFps = YES;
+                }
+                continue;
+            }
+        }
+
+        [out addObject:line];
+    }
+
+    if (inVideo) {
+        append_missing_video_keys(out, seenMode, seenWidth, seenHeight,
+                                  seenFullscreen, seenFps,
+                                  mode, width, height, fullscreen, fps);
+    }
+
+    if (!foundVideo) {
+        [out addObject:@""];
+        [out addObject:@"[video]"];
+        [out addObject:[NSString stringWithFormat:@"mode = %@", mode]];
+        [out addObject:[NSString stringWithFormat:@"width = %ld", (long)width]];
+        [out addObject:[NSString stringWithFormat:@"height = %ld", (long)height]];
+        [out addObject:[NSString stringWithFormat:@"fullscreen = %d", fullscreen ? 1 : 0]];
+        [out addObject:[NSString stringWithFormat:@"fps_limit = %ld", (long)fps]];
+    }
+
+    NSString *updated = [out componentsJoinedByString:@"\n"];
+    BOOL ok = [updated writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    if (!ok) NSLog(@"PvZ2Native launcher: cannot write config.ini: %@", error);
+    return ok;
+}
+
+int pvz2_macos_show_launcher(const char *ini_path, const pvz2_config_t *cfg) {
+    @autoreleasepool {
+        if (!cfg) return 1;
+
+        [NSApplication sharedApplication];
+
+
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"PvZ2Native";
+        alert.informativeText = @"Choose video settings before starting the game.";
+        alert.alertStyle = NSAlertStyleInformational;
+
+        NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 360, 122)];
+
+        NSTextField *resolutionLabel = [NSTextField labelWithString:@"Resolution"];
+        resolutionLabel.frame = NSMakeRect(0, 91, 100, 22);
+        [view addSubview:resolutionLabel];
+
+        NSPopUpButton *resolution = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(110, 88, 245, 28)];
+        [resolution addItemsWithTitles:@[@"Auto", @"1280 × 720", @"1920 × 1080", @"Native"]];
+        [view addSubview:resolution];
+
+        if (cfg->video_width == 1280 && cfg->video_height == 720) {
+            [resolution selectItemAtIndex:1];
+        } else if (cfg->video_width == 1920 && cfg->video_height == 1080) {
+            [resolution selectItemAtIndex:2];
+        } else if (strcmp(cfg->video_mode, "native") == 0) {
+            [resolution selectItemAtIndex:3];
+        } else {
+            [resolution selectItemAtIndex:0];
+        }
+
+        NSTextField *fpsLabel = [NSTextField labelWithString:@"FPS limit"];
+        fpsLabel.frame = NSMakeRect(0, 53, 100, 22);
+        [view addSubview:fpsLabel];
+
+        NSPopUpButton *fpsPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(110, 50, 245, 28)];
+        [fpsPopup addItemsWithTitles:@[@"60 FPS", @"120 FPS", @"Unlimited"]];
+        if (cfg->fps_limit == 120) {
+            [fpsPopup selectItemAtIndex:1];
+        } else if (cfg->fps_limit == 0) {
+            [fpsPopup selectItemAtIndex:2];
+        } else {
+            [fpsPopup selectItemAtIndex:0];
+        }
+        [view addSubview:fpsPopup];
+
+        NSButton *fullscreen = [[NSButton alloc] initWithFrame:NSMakeRect(110, 12, 245, 24)];
+        fullscreen.buttonType = NSButtonTypeSwitch;
+        fullscreen.title = @"Fullscreen";
+        fullscreen.state = cfg->video_fullscreen ? NSControlStateValueOn : NSControlStateValueOff;
+        [view addSubview:fullscreen];
+
+        alert.accessoryView = view;
+        [alert addButtonWithTitle:@"Play"];
+        [alert addButtonWithTitle:@"Cancel"];
+
+        NSModalResponse response = [alert runModal];
+        if (response != NSAlertFirstButtonReturn) return 0;
+
+        NSString *mode = @"auto";
+        NSInteger width = 0;
+        NSInteger height = 0;
+
+        switch (resolution.indexOfSelectedItem) {
+            case 1:
+                width = 1280;
+                height = 720;
+                break;
+            case 2:
+                width = 1920;
+                height = 1080;
+                break;
+            case 3:
+                mode = @"native";
+                break;
+            default:
+                break;
+        }
+
+        NSInteger fps = 60;
+        if (fpsPopup.indexOfSelectedItem == 1) fps = 120;
+        else if (fpsPopup.indexOfSelectedItem == 2) fps = 0;
+
+        if (!write_video_settings(ini_path, mode, width, height,
+                                  fullscreen.state == NSControlStateValueOn, fps)) {
+            NSAlert *errorAlert = [[NSAlert alloc] init];
+            errorAlert.messageText = @"Could not save video settings";
+            errorAlert.informativeText = @"PvZ2Native could not update config.ini.";
+            [errorAlert runModal];
+            return 0;
+        }
+
+        return 1;
+    }
+}

--- a/pvz2native/src/runtime/dynarmic_config.cpp
+++ b/pvz2native/src/runtime/dynarmic_config.cpp
@@ -487,6 +487,17 @@ void Pvz2Env::handle_import_call(std::uint32_t idx) {
 }
 
 void Pvz2Env::CallSVC(std::uint32_t swi) {
+    /* During orderly session teardown, spawned guest workers must stop at the
+     * next host boundary rather than return into guest code. Blocking sync
+     * imports are explicitly awakened by request_guest_shutdown(), so every
+     * long-lived worker eventually reaches this boundary. */
+    if (guest_tls::self_id != 1 &&
+        rt->shutdown_requested.load(std::memory_order_acquire)) {
+        should_halt = true;
+        jit->HaltExecution();
+        return;
+    }
+
     if (swi == 0) {
         if (verbose_boot()) {
             std::lock_guard<std::mutex> lg(rt->log_lock);
@@ -872,13 +883,39 @@ std::uint32_t Pvz2Env::join_guest_thread_impl(GuestRuntime *rt, std::uint32_t id
     return it == rt->thread_retvals.end() ? 0 : it->second;
 }
 
+void request_guest_shutdown(GuestRuntime *rt) {
+    if (rt == nullptr) return;
+
+    rt->shutdown_requested.store(true, std::memory_order_release);
+
+    /* A worker may be asleep indefinitely inside either primitive. Merely
+     * setting the flag is insufficient: wake current waiters so their blocking
+     * imports can observe shutdown_requested and halt their guest JITs. */
+    {
+        std::lock_guard<std::mutex> lock(rt->conds_lock);
+        for (auto &entry : rt->guest_conds) {
+            entry.second->cv.notify_all();
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(rt->sems_lock);
+        for (auto &entry : rt->guest_sems) {
+            entry.second->cv.notify_all();
+        }
+    }
+}
+
 void join_leftover_guest_threads(GuestRuntime *rt) {
     std::vector<std::thread> leftover;
     {
         std::lock_guard<std::mutex> lock(rt->threads_lock);
-        for (auto &kv : rt->threads) leftover.push_back(std::move(kv.second));
+        for (auto &kv : rt->threads) {
+            leftover.push_back(std::move(kv.second));
+        }
         rt->threads.clear();
     }
+
     for (auto &th : leftover) {
         if (th.joinable()) th.join();
     }

--- a/pvz2native/src/session.cpp
+++ b/pvz2native/src/session.cpp
@@ -266,16 +266,22 @@ extern "C" int pvz2_session_frame(pvz2_session_t *s) {
 
 extern "C" void pvz2_session_end(pvz2_session_t *s) {
     if (s == nullptr) return;
-    /* Stop the audio device first: its callback reads host buffers owned by the
-     * audio layer, and this is also what releases the guest thread parked in
-     * wait_for_completion() so it can unwind before its Jit goes away. */
+
+    /* Stop the host audio device first. Its completion worker is a guest thread
+     * and must be allowed to unwind before any guest JIT is destroyed. */
     pvz2native::audio::shutdown();
-    /* Any guest thread that outlived the call that spawned it holds raw
-     * pointers to both img and rt, so it must be joined before either dies. */
+
+    /* Long-lived guest workers can sleep indefinitely in pthread condition
+     * variables or semaphores. Request a cooperative stop before joining them,
+     * so every worker leaves its blocking import and unwinds its JIT normally. */
+    rt_::request_guest_shutdown(&s->rt);
+
+    /* Guest-thread contexts retain raw pointers to both the runtime and image. */
     rt_::join_leftover_guest_threads(&s->rt);
-    /* The shared main-thread Jit points at rt->monitor and its Env points at
-     * img, so it has to go before either -- see GuestThreadCtx. */
+
+    /* The main JIT references rt->monitor and the loaded guest image. */
     rt_::release_main_ctx();
+
     pvz2_elf_free(&s->img);
     rt_::set_session_image(nullptr, nullptr);
     delete s;

--- a/readme_spanish.md
+++ b/readme_spanish.md
@@ -91,7 +91,7 @@ Añadir una versión nueva = una entrada en `kVersions` de [symbols.cpp](pvz2nat
 - **Linux:** GCC o Clang con soporte C++20.
 - **macOS Apple Silicon:** Apple Clang / Xcode Command Line Tools, Ninja y Python 3.
 - **GPU con OpenGL 2.0** o superior.
-- Tu propia copia de **`libPVZ2.so`** y del **`.obb`** correspondiente, extraídos del juego de Android.
+- Tus propios archivos legales del juego. En macOS la forma más fácil es **un APK + su OBB correspondiente**; `compile-macos.sh` extrae automáticamente el `libPVZ2.so` ARM32 necesario.
 
 ---
 
@@ -180,41 +180,99 @@ make pvz2native
 
 ### macOS (Apple Silicon)
 
-La compilación para macOS se ejecuta de forma nativa en Apple Silicon
-(`arm64`). El script auxiliar crea su propio entorno virtual de Python para
-GLAD, configura CMake para `arm64` y compila el frontend A32 usando el backend
-AArch64 de Dynarmic.
+La compilación de macOS se ejecuta **de forma nativa en Apple Silicon
+(`arm64`)**. El `libPVZ2.so` de Android sigue siendo ARM32; Dynarmic traduce ese
+código invitado A32 al host AArch64 durante la ejecución.
 
-Requisitos:
+> [!IMPORTANT]
+> PvZ2Native **no incluye, aloja ni descarga Plants vs. Zombies 2**.
+> Debes aportar archivos de tu propia copia legal del juego.
 
-- Xcode Command Line Tools / Apple Clang
-- CMake
-- Ninja
-- Python 3
+#### Preparación para principiantes — solo dos archivos del juego
 
-Para compilar en Release:
+No necesitas abrir el APK ni extraer `libPVZ2.so` manualmente.
+
+1. Clona el repositorio con sus submódulos:
+
+```bash
+git clone --recursive https://github.com/OptiJuegos/PvZ2Native.git
+cd PvZ2Native
+```
+
+2. Instala las herramientas de compilación de macOS si faltan:
+
+```bash
+xcode-select --install
+```
+
+Si tienes Homebrew:
+
+```bash
+brew install cmake ninja python3
+```
+
+3. Abre la carpeta `game/` y copia directamente dentro de ella exactamente
+   **un APK** y su **OBB correspondiente**:
+
+```text
+PvZ2Native/
+├── game/
+│   ├── tu-propia-copia-de-pvz2.apk
+│   └── main.<versionCode>.<paquete>.obb
+├── compile-macos.sh
+└── ...
+```
+
+Por ejemplo, uno de los OBB actualmente soportados se llama:
+
+```text
+main.147.com.ea.game.pvz2_row.obb
+```
+
+No renombres el OBB. Su nombre contiene información que utiliza el juego.
+
+4. Compila:
 
 ```bash
 ./compile-macos.sh
 ```
 
-Opciones útiles:
+El script hará automáticamente:
 
-| Opción | Descripción |
-| --- | --- |
-| `-c, --clean` | Borra `build-macos/` antes de configurar |
-| `-d, --debug` | Configura una compilación Debug |
-| `-r, --release` | Configura una compilación Release (por defecto) |
-| `-j, --jobs N` | Compila usando `N` trabajos en paralelo |
-| `-h, --help` | Muestra las opciones disponibles |
+```text
+comprobar macOS / Apple Silicon y herramientas
+        ↓
+buscar tu APK y OBB dentro de game/
+        ↓
+extraer lib/armeabi-v7a/libPVZ2.so desde el APK
+        ↓
+verificar que libPVZ2.so sea un ELF ARM32
+        ↓
+configurar CMake para macOS arm64 nativo
+        ↓
+compilar PvZ2Native
+        ↓
+copiar los archivos preparados a build-macos/pvz2native/lib/
+```
 
-Ejemplos:
+No se descarga nada de EA/PopCap y Git nunca añade los archivos de `game/`.
+
+5. Cuando termine la compilación, ejecuta:
 
 ```bash
-./compile-macos.sh --clean --release
-./compile-macos.sh --debug
-./compile-macos.sh --jobs 4
+./build-macos/pvz2native/pvz2native
 ```
+
+En macOS aparece primero un pequeño launcher nativo. Este solo modifica las
+opciones existentes de `[video]` en `config.ini`, por lo que el sistema normal
+de configuración continúa siendo la única fuente de verdad.
+
+El launcher permite elegir:
+
+- resolución inicial (`Auto`, `1280×720`, `1920×1080`, `Native`)
+- `60 FPS`, `120 FPS` o `Unlimited`
+- iniciar en ventana o pantalla completa
+- `Play` / `Cancel`
 
 El ejecutable queda en:
 
@@ -222,13 +280,70 @@ El ejecutable queda en:
 build-macos/pvz2native/pvz2native
 ```
 
-El script **no incluye ni descarga archivos del juego**. Debes proporcionar tu
-propio `libPVZ2.so` legal y el `.obb` correspondiente, tal como se explica más
-abajo.
+y debe identificarse como ejecutable nativo de Apple Silicon:
+
+```text
+Mach-O 64-bit executable arm64
+```
+
+#### Método avanzado / original para los archivos
+
+Si ya extrajiste tú mismo la librería de Android, puedes conservar el método
+original del proyecto:
+
+```text
+game/
+├── libPVZ2.so
+└── archivo-correspondiente.obb
+```
+
+Si existen tanto un APK como `game/libPVZ2.so`, tiene prioridad el
+`libPVZ2.so` ya extraído.
+
+#### Opciones de compilación en macOS
+
+| Opción | Descripción |
+| --- | --- |
+| `-c, --clean` | Borra `build-macos/` antes de configurar |
+| `-d, --debug` | Compila Debug |
+| `-r, --release` | Compila Release (por defecto) |
+| `-j, --jobs N` | Usa `N` trabajos de compilación en paralelo |
+| `-n, --no-assets` | Solo compila; no copia/extrae archivos del juego |
+| `-v, --verbose` | Muestra toda la salida de CMake/compilación |
+| `-h, --help` | Muestra la ayuda |
+
+Ejemplos:
+
+```bash
+./compile-macos.sh --clean --release
+./compile-macos.sh --debug
+./compile-macos.sh --jobs 4
+./compile-macos.sh --no-assets
+```
+
+El log completo cuando no se usa `--verbose` queda en:
+
+```text
+build-macos/compile-macos.log
+```
 
 ---
 
 ## ▶️ Ejecución
+
+### macOS
+
+Después de que `./compile-macos.sh` prepare la compilación y tus propios
+archivos del juego:
+
+```bash
+./build-macos/pvz2native/pvz2native
+```
+
+Primero aparece el launcher nativo de video de macOS; al elegir **Play** continúa
+el mismo núcleo PvZ2Native usado por el ejecutable normal.
+
+### Distribución general / manual
 
 1. Coloca los archivos del juego junto al ejecutable, por defecto en una carpeta `lib/`:
 

--- a/readme_spanish.md
+++ b/readme_spanish.md
@@ -2,7 +2,7 @@
 
 📖 **Español** · [English](README.md)
 
-**Ejecuta la librería nativa real de *Plants vs. Zombies 2* para Android (`libPVZ2.so`, ARM32) en PC.** Lo único que se emula es el **procesador**: PvZ2 solo existe compilado para ARM (no hay build x86/x64), así que un JIT traduce sus instrucciones ARM a x86_64. Todo lo demás —Android, JNI, libc, OpenGL ES, sistema de archivos— **no se emula, se reimplementa de forma nativa**, igual que hace **Wine** con Windows.
+**Ejecuta la librería nativa real de *Plants vs. Zombies 2* para Android (`libPVZ2.so`, ARM32) en PC.** Lo único que se emula es el **procesador**: PvZ2 solo existe compilado para ARM (no hay build x86/x64), así que un JIT traduce sus instrucciones ARM a la arquitectura nativa del host (x86_64 o arm64). Todo lo demás —Android, JNI, libc, OpenGL ES, sistema de archivos— **no se emula, se reimplementa de forma nativa**, igual que hace **Wine** con Windows.
 
 > [!WARNING]
 > Proyecto experimental y en desarrollo activo. Arranca hasta la carga del menú principal; el renderizado, el audio y la entrada están en progreso. **No incluye el juego**: debes aportar tu propio `libPVZ2.so` y tu propio `.obb`.
@@ -13,7 +13,7 @@
 
 No es un *port* del código fuente del juego. Es un **híbrido de dos técnicas**, y la distinción importa:
 
-- **Solo la CPU se emula.** El binario del juego es código máquina ARM y PvZ2 nunca se compiló para x86/x64, así que no hay forma de ejecutarlo directamente en un procesador de PC. Un JIT (dynarmic) lee esas instrucciones ARM y las traduce a x86_64 sobre la marcha. Esta es la única parte "emulada".
+- **Solo la CPU se emula.** El binario del juego es código máquina ARM y PvZ2 nunca se compiló para x86/x64, así que no hay forma de ejecutarlo directamente en un procesador de PC. Un JIT (dynarmic) lee esas instrucciones ARM y las traduce a la arquitectura nativa del host (x86_64 o arm64) sobre la marcha. Esta es la única parte "emulada".
 - **Android NO se emula: se reimplementa.** Cuando el juego llama a una función de Android (abrir un archivo, dibujar con OpenGL ES, reservar memoria, invocar Java…), esa llamada la atiende **código nativo de PC** que hace el trabajo real usando la API equivalente del escritorio. No hay un Android virtual corriendo debajo; hay una **reimplementación** de las funciones que el juego necesita.
 
 Es exactamente el enfoque de **Wine** — *"Wine Is Not an Emulator"* — llevado un paso más allá: Wine reimplementa las llamadas de Windows sin emular nada porque los `.exe` ya son x86; aquí, como el juego es ARM, además hay que emular la CPU. El resto de la filosofía es idéntica: **traducir llamadas, no simular una máquina completa.**
@@ -25,7 +25,7 @@ Es exactamente el enfoque de **Wine** — *"Wine Is Not an Emulator"* — llevad
                         │  instrucciones ARM
                         ▼
 ┌──────────────────────────────────────────────┐
-│   dynarmic  —  JIT ARM32 → x86_64             │   ← ÚNICO componente emulado
+│   dynarmic  —  JIT ARM32 → x86_64 / arm64     │   ← ÚNICO componente emulado
 └───────────────────────┬──────────────────────┘      (solo la CPU)
                         │  llamadas a "Android"
                         ▼
@@ -39,7 +39,7 @@ Es exactamente el enfoque de **Wine** — *"Wine Is Not an Emulator"* — llevad
                         │
                         ▼
 ┌──────────────────────────────────────────────┐
-│   Windows x64  ·  SDL2  ·  OpenGL 2.0 (glad)  │
+│ Windows/Linux x64 · macOS arm64 · SDL2 · OpenGL │
 └──────────────────────────────────────────────┘
 ```
 
@@ -85,10 +85,11 @@ Añadir una versión nueva = una entrada en `kVersions` de [symbols.cpp](pvz2nat
 
 ## ⚙️ Requisitos
 
-- **(64 bits) Windows o Linux** (el ejecutable es x86_64 estático; no hay build de 32 bits — dynarmic solo trae backends para x86_64/arm64/riscv64).
+- **Windows o Linux de 64 bits**, o **macOS en Apple Silicon (arm64)**. No existe build host de 32 bits — dynarmic dispone de backends para x86_64, arm64 y riscv64.
 - **CMake** (3.1+).
 - **Windows:** MinGW-w64 (GCC con soporte C++20).
 - **Linux:** GCC o Clang con soporte C++20.
+- **macOS Apple Silicon:** Apple Clang / Xcode Command Line Tools, Ninja y Python 3.
 - **GPU con OpenGL 2.0** o superior.
 - Tu propia copia de **`libPVZ2.so`** y del **`.obb`** correspondiente, extraídos del juego de Android.
 
@@ -176,6 +177,54 @@ Recompilación incremental (tras el primer `cmake`):
 cd build
 make pvz2native
 ```
+
+### macOS (Apple Silicon)
+
+La compilación para macOS se ejecuta de forma nativa en Apple Silicon
+(`arm64`). El script auxiliar crea su propio entorno virtual de Python para
+GLAD, configura CMake para `arm64` y compila el frontend A32 usando el backend
+AArch64 de Dynarmic.
+
+Requisitos:
+
+- Xcode Command Line Tools / Apple Clang
+- CMake
+- Ninja
+- Python 3
+
+Para compilar en Release:
+
+```bash
+./compile-macos.sh
+```
+
+Opciones útiles:
+
+| Opción | Descripción |
+| --- | --- |
+| `-c, --clean` | Borra `build-macos/` antes de configurar |
+| `-d, --debug` | Configura una compilación Debug |
+| `-r, --release` | Configura una compilación Release (por defecto) |
+| `-j, --jobs N` | Compila usando `N` trabajos en paralelo |
+| `-h, --help` | Muestra las opciones disponibles |
+
+Ejemplos:
+
+```bash
+./compile-macos.sh --clean --release
+./compile-macos.sh --debug
+./compile-macos.sh --jobs 4
+```
+
+El ejecutable queda en:
+
+```text
+build-macos/pvz2native/pvz2native
+```
+
+El script **no incluye ni descarga archivos del juego**. Debes proporcionar tu
+propio `libPVZ2.so` legal y el `.obb` correspondiente, tal como se explica más
+abajo.
 
 ---
 
@@ -270,6 +319,7 @@ PvZ2Native/
 ├── SDL/  glad/  zlib/  stb/  third_party/
 ├── compile.bat           ← build con MinGW
 ├── compile.sh            ← build en Linux
+├── compile-macos.sh      ← build macOS Apple Silicon
 ├── CMakeLists.txt
 └── README.md
 ```


### PR DESCRIPTION
## Summary

Adds native macOS Apple Silicon (`arm64`) support to PvZ2Native while preserving the existing CMake architecture, `config.ini` workflow, version fingerprinting, and game-asset policy.

This remains the same PvZ2Native core: the Android ARM32 `libPVZ2.so` runs through Dynarmic's A32 frontend and AArch64 host backend, while Android/JNI/libc/GLES/filesystem functionality remains natively reimplemented by PvZ2Native.

## What this PR adds

- Native macOS Apple Silicon (`arm64`) build support
- Dynarmic A32 guest → AArch64 host execution
- Reproducible `compile-macos.sh` using CMake, Ninja, Apple Clang, and an isolated Python environment for GLAD
- Native Cocoa video launcher integrated into the same `pvz2native` executable
  - `Auto`, `1280×720`, `1920×1080`, or `Native`
  - `60 FPS`, `120 FPS`, or `Unlimited`
  - windowed/fullscreen start
  - `Play` / `Cancel`
- Launcher only updates the existing `[video]` section; `config.ini` remains the single source of truth
- Easy `game/` asset workflow following the same philosophy as the existing `compile.sh`
- Advanced/original `libPVZ2.so + OBB` workflow remains supported
- Automatic use of one unambiguous OBB in `lib/` when `[paths] obb` is left unset
- Automatic `package_name` derivation from `main.<versionCode>.<package>.obb` when not explicitly configured
- Cooperative guest-thread shutdown before Dynarmic/JIT teardown
- AppleClang portability fix for pthread timeout conversion
- Beginner-friendly English and Spanish documentation
- `game/README.md` explaining exactly where user-owned game files belong
- Game binaries/assets remain ignored by Git

## Beginner macOS workflow

PvZ2Native does **not** include, host, or download Plants vs. Zombies 2.

### 1. Clone the project

```bash
git clone --recursive https://github.com/OptiJuegos/PvZ2Native.git
cd PvZ2Native
```

### 2. Install the macOS build tools if needed

```bash
xcode-select --install
```

With Homebrew installed:

```bash
brew install cmake ninja python3
```

### 3. Put exactly two user-owned game files inside `game/`

```text
PvZ2Native/
├── game/
│   ├── your-own-pvz2-copy.apk
│   └── main.<versionCode>.<package>.obb
├── compile-macos.sh
└── ...
```

For example, one currently supported OBB is:

```text
main.147.com.ea.game.pvz2_row.obb
```

The user does **not** need to open the APK or extract `libPVZ2.so` manually.

### 4. Build

```bash
./compile-macos.sh
```

The script:

```text
checks macOS / Apple Silicon tools
        ↓
finds the APK and OBB in game/
        ↓
extracts lib/armeabi-v7a/libPVZ2.so from the APK
        ↓
verifies that libPVZ2.so is an ARM32 ELF
        ↓
configures CMake for native macOS arm64
        ↓
builds PvZ2Native
        ↓
copies the prepared game files to build-macos/pvz2native/lib/
```

### 5. Run

```bash
./build-macos/pvz2native/pvz2native
```

The native macOS video launcher appears first. Choosing **Play** continues into the same PvZ2Native core.

## Advanced/original asset workflow

Users who already extracted the Android library can keep the original project style:

```text
game/
├── libPVZ2.so
└── matching-file.obb
```

If both an APK and `game/libPVZ2.so` are present, the already extracted `libPVZ2.so` takes priority.

## Asset policy

No APK, OBB, `libPVZ2.so`, or other EA/PopCap asset is included, hosted, committed, or downloaded by this PR.

Users must provide files from their own legally obtained copy of the game. The macOS helper only operates on those local files.

## Validation

Validated from a completely clean Release build on Apple Silicon:

- Host: Apple M4 / macOS arm64
- Output: `Mach-O 64-bit executable arm64`
- PvZ2 tested: **4.5.2**
- OBB tested: `main.147.com.ea.game.pvz2_row.obb`
- 1280×720 windowed launcher path validated
- 1920×1080 fullscreen validated
- 60 / 120 FPS paths exercised
- Unlimited FPS setting persists correctly
- Rendering exercised successfully
- Audio exercised successfully
- Mouse/touch input exercised successfully
- Save persistence exercised successfully
- Resize/fullscreen handling exercised successfully
- Clean Escape shutdown with guest workers cooperatively released/joined
- Final process exit status: `0`
- No final-run `std::system_error`, mutex teardown failure, abort, segmentation fault, or bus error observed

The existing byte-fingerprint/version table remains authoritative. This PR does **not** claim macOS validation for game versions that were not actually exercised on the tested Mac host.

## Documentation

The full macOS workflow is documented in:

- `README.md` — English
- `readme_spanish.md` — Spanish
- `game/README.md` — short instructions placed directly where users put their own game files

## Design intent

The macOS changes are deliberately additive and platform-specific where possible:

- Windows keeps `compile.bat`
- Linux keeps `compile.sh`
- macOS gets `compile-macos.sh`
- the same CMake project builds the same PvZ2Native core
- the Cocoa launcher is Apple-only
- `config.ini` remains authoritative
- existing version detection remains authoritative
- game assets remain external to the repository

## Note about #6

This PR includes the same AppleClang `system_clock::duration` portability fix proposed in #6 because it is required by the complete macOS build validated here. Credit to the author of #6 for identifying that portability issue; the maintainer can decide whether to merge #6 first or treat that small fix as superseded by this broader macOS port.
